### PR TITLE
Add unittest language tests

### DIFF
--- a/test_language.py
+++ b/test_language.py
@@ -1,47 +1,46 @@
 # -*- coding: utf-8 -*-
-"""
-Demo script to test the language system
-"""
+"""Language system tests and demo run"""
 
-from PyQt5 import QtWidgets, QtCore
-import sys
 import os
+import sys
+import unittest
 
 # Add current directory to path so we can import our modules
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from starter import *
 from language_manager import lang_manager
 
-def test_language_system():
-    """Test the language system"""
-    
-    # Test Thai
-    print("=== Testing Thai ===")
-    lang_manager.set_language('th')
-    print(f"App Title: {lang_manager.tr('app_title')}")
-    print(f"Calculate: {lang_manager.tr('common.calculate')}")
-    print(f"Beam Width: {lang_manager.tr('beam.width')}")
-    
-    # Test English
-    print("\n=== Testing English ===")
-    lang_manager.set_language('en')
-    print(f"App Title: {lang_manager.tr('app_title')}")
-    print(f"Calculate: {lang_manager.tr('common.calculate')}")
-    print(f"Beam Width: {lang_manager.tr('beam.width')}")
-    
-    # Test Chinese
-    print("\n=== Testing Chinese ===")
-    lang_manager.set_language('zh')
-    print(f"App Title: {lang_manager.tr('app_title')}")
-    print(f"Calculate: {lang_manager.tr('common.calculate')}")
-    print(f"Beam Width: {lang_manager.tr('beam.width')}")
+class TestLanguageSystem(unittest.TestCase):
+    """Test translations for supported languages."""
+
+    expected = {
+        'th': {
+            'app_title': 'โปรแกรมออกแบบคอนกรีตเสริมเหล็ก',
+            'calculate': 'คำนวณ',
+        },
+        'en': {
+            'app_title': 'Reinforced Concrete Design Program',
+            'calculate': 'Calculate',
+        },
+        'zh': {
+            'app_title': '鋼筋混凝土設計程式',
+            'calculate': '計算',
+        },
+    }
+
+    def test_translations(self):
+        for lang, values in self.expected.items():
+            with self.subTest(lang=lang):
+                lang_manager.set_language(lang)
+                self.assertEqual(lang_manager.tr('app_title'), values['app_title'])
+                self.assertEqual(lang_manager.tr('common.calculate'), values['calculate'])
 
 if __name__ == "__main__":
-    # Run language test
-    test_language_system()
-    
-    # Start the application
+    unittest.main(exit=False)
+
+    from PyQt5 import QtWidgets
+    from menu_controller import MenuController
+
     print("\n=== Starting Application ===")
     app = QtWidgets.QApplication(sys.argv)
     the_mainwindow = MenuController()


### PR DESCRIPTION
## Summary
- convert `test_language_system` to a unittest-based test
- verify `app_title` and `common.calculate` strings for TH/EN/ZH
- still allow launching the app from `__main__`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c8ed137c832ea216f333a71f2eb5